### PR TITLE
Add the `arrays` Namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     ".": "./dist/index.js",
     "./examples": "./dist/examples/index.js",
     "./examples/exampleTool": "./dist/examples/exampleTool/index.js",
+    "./arrays": "./dist/arrays/index.js",
     "./types": "./dist/types/index.js",
     "./types/baseTypes": "./dist/types/baseTypes/index.js",
     "./types/isAny": "./dist/types/isAny/index.js",

--- a/toolkit/arrays/README.md
+++ b/toolkit/arrays/README.md
@@ -1,0 +1,55 @@
+# `arrays`
+Utility tools for working with [Dynamic-Length Arrays](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array).
+
+
+## NPM Package Usage
+You can directly import tools into your project:
+```ts
+// These imports are all equivalent
+import Example from "typescript-toolkit/arrays/example";
+import * as Example from "typescript-toolkit/arrays/example";
+import { Example } from "typescript-toolkit/arrays";
+
+type Test = Example<true>;
+```
+
+You can also import the namespace into your project:
+```ts
+// These imports are all equivalent
+import { arrays } from "typescript-toolkit";
+import arrays from "typescript-toolkit/arrays";
+import * as arrays from "typescript-toolkit/arrays";
+
+type Test = arrays.Example<true>;
+```
+
+For JavaScript projects, you can use [`import()` types](https://www.typescriptlang.org/docs/handbook/modules/reference.html#import-types) or the [`@import` tag](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import) to import the namespace or individual types:
+```js
+/**
+ * @typedef {import("typescript-toolkit/arrays").Example<true>} Test
+ */
+/**
+ * @typedef {import("typescript-toolkit").arrays.Example<true>} Test
+ */
+
+/**
+ * @import Example from "typescript-toolkit/arrays/example"
+ * @import { Example } from "typescript-toolkit/arrays"
+ */
+/**
+ * @typedef {Example<true>} Test
+ */
+
+/**
+ * @import { arrays } from "typescript-toolkit"
+ * @import arrays from "typescript-toolkit/arrays"
+ */
+/**
+ * @typedef {arrays.Example<true>} Test
+ */
+```
+
+
+## Changelog
+- [`1.0.0`](https://github.com/FusedKush/typescript-toolkit/tree/releases/1.0.0):
+  - Added `arrays`

--- a/toolkit/arrays/index.ts
+++ b/toolkit/arrays/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Utility tools for working with
+ * [Dynamic-Length Arrays](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array).
+ * 
+ * @since 1.0.0
+ */
+declare module "./index.js";
+
+export * as default from "./index.js";

--- a/toolkit/index.ts
+++ b/toolkit/index.ts
@@ -3,6 +3,7 @@
  */
 declare module "./index.js";
 
+export * as arrays from "./arrays/index.js";
 export * as examples from "./examples/index.js";
 export * as types from "./types/index.js";
 export * as default from "./index.js";


### PR DESCRIPTION
Add the `arrays` Namespace for utility tools used when working with [Dynamic-Length Arrays](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array).